### PR TITLE
Removing default for Property::Object (MySQL TEXT can not have default) property

### DIFF
--- a/lib/dm-migrations/adapters/dm-mysql-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-mysql-adapter.rb
@@ -61,6 +61,10 @@ module DataMapper
             schema.delete(:default)
           end
 
+          if property.kind_of?(Property::Object)
+            schema.delete(:default)
+          end
+
           if property.kind_of?(Property::Integer)
             min = property.min
             max = property.max


### PR DESCRIPTION
https://github.com/ujifgc/dm-migrations/commit/c5c3ffaf37136a343af5bc9b4dc9f9fdf7e40b2e
