### PR TITLE
fix table creation for postgresql

### DIFF
--- a/lib/dm-migrations/adapters/dm-postgres-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-postgres-adapter.rb
@@ -34,6 +34,13 @@ module DataMapper
 
       module SQL #:nodoc:
 #        private  ## This cannot be private for current migrations
+        # @api private
+        def create_table_statement(connection, model, properties)
+          DataMapper::Ext::String.compress_lines(<<-SQL)
+            CREATE TABLE #{quote_name(model.storage_name(name))}
+            (#{properties.map { |property| property_schema_statement(connection, property_schema_hash(property)) }.join(', ')})
+          SQL
+        end
 
         # @api private
         def supports_drop_table_if_exists?

--- a/lib/dm-migrations/sql/postgres.rb
+++ b/lib/dm-migrations/sql/postgres.rb
@@ -21,7 +21,7 @@ module SQL
 
     def property_schema_statement(connection, schema)
       if supports_serial? && schema[:serial]
-        statement = "#{schema[:quote_column_name]} SERIAL PRIMARY KEY"
+        statement = "#{quote_name(schema[:name])} SERIAL PRIMARY KEY"
       else
         statement = super
         if schema.has_key?(:sequence_name)


### PR DESCRIPTION
with definition

<pre>property :id, Serial</pre>

it was generating query like:

<pre>CREATE TABLE "foobars" ( SERIAL PRIMARY KEY, ... ,  PRIMARY KEY("id"))</pre>

while proper one should be:

<pre>CREATE TABLE "foobars" ( "id" SERIAL PRIMARY KEY, ... )</pre>


This fixes the issue.
