### PR TITLE
Allowing bytea columns to migrate by ignoring length

### DIFF
--- a/lib/dm-migrations/adapters/dm-do-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-do-adapter.rb
@@ -202,7 +202,7 @@ module DataMapper
 
           schema_primitive = schema[:primitive]
 
-          if dump_class.equal?(String) && schema_primitive != 'TEXT' && schema_primitive != 'CLOB' && schema_primitive != 'NVARCHAR'
+          if dump_class.equal?(String) && schema_primitive != 'TEXT' && schema_primitive != 'CLOB' && schema_primitive != 'NVARCHAR' && schema_primitive != 'BYTEA'
             schema[:length] = property.length
           elsif dump_class.equal?(BigDecimal) || dump_class.equal?(Float)
             schema[:precision] = property.precision


### PR DESCRIPTION
I found that I was unable to migrate into postgres when defining a binary property because the column was being defined with the default length.
Currently TEXT, CLOB and NVARCHAR were ignoring the length so I've added bytea to this list.
