### PR TITLE
Added a spec checking the mysql specific SQL for changing the type of a column.

### DIFF
--- a/spec/integration/sql_spec.rb
+++ b/spec/integration/sql_spec.rb
@@ -138,16 +138,22 @@ describe "SQL generation" do
         @migration.should respond_to(:modify_table)
       end
 
-      case DataMapper::Spec.adapter_name.to_sym
-      when :postgres
+      describe "#change_column" do
         before do
           @modifier = DataMapper::Migration::TableModifier.new(@adapter, :people) do
             change_column :name, 'VARCHAR(200)'
           end
         end
 
-        it "should alter the column" do
-          @modifier.to_sql.should == %q{ALTER TABLE "people" ALTER COLUMN "name" VARCHAR(200)}
+        case DataMapper::Spec.adapter_name.to_sym
+        when :postgres
+          it "should alter the column" do
+            @modifier.to_sql.should == %q{ALTER TABLE "people" ALTER COLUMN "name" VARCHAR(200)}
+          end
+        when :mysql
+          it "should modify the column" do
+            @modifier.to_sql.should == %q{ALTER TABLE `people` MODIFY COLUMN `name` VARCHAR(200)}
+          end
         end
       end
     end


### PR DESCRIPTION
There was no spec for `change_column` with the mysql adapter, which generates MySQL specific SQL.
