### PR TITLE
Backport bytea migration fix to v1.2

### DIFF
--- a/lib/dm-migrations/adapters/dm-do-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-do-adapter.rb
@@ -202,7 +202,7 @@ module DataMapper
 
           schema_primitive = schema[:primitive]
 
-          if primitive == String && schema_primitive != 'TEXT' && schema_primitive != 'CLOB' && schema_primitive != 'NVARCHAR'
+          if primitive == String && schema_primitive != 'TEXT' && schema_primitive != 'CLOB' && schema_primitive != 'NVARCHAR' && schema_primitive != 'BYTEA'
             schema[:length] = property.length
           elsif primitive == BigDecimal || primitive == Float
             schema[:precision] = property.precision


### PR DESCRIPTION
This backports f091e37dbc8982b70c7743c3190ab65c2785c9f6 to the `release-1.2` branch, it'd be great if there was a release of v1.2 that included this fix.
