### PR TITLE
An exception is raised when trying to migrate with MasterSlaveAdapter

### DIFF
--- a/lib/dm-migrations/migration.rb
+++ b/lib/dm-migrations/migration.rb
@@ -288,6 +288,8 @@ module DataMapper
     def setup!
       @adapter = DataMapper.repository(@repository).adapter
 
+      @adapter = @adapter.master if @adapter.respond_to? :master
+
       case @adapter.class.name
       when /Sqlite/   then @adapter.extend(SQL::Sqlite)
       when /Mysql/    then @adapter.extend(SQL::Mysql)


### PR DESCRIPTION
I can't figure out what the most sensible solution is to this issue, but this is one possible solution.

Since dm-migrations only supports adapters with class names matching the specified expressions (`/Sqlite/` `/Mysql/` and `/Postgres/`), any other adapter is excluded, which perhaps makes sense if the underlying libraries only support those databases.  However, this particular adapter just aggregates child adapters that can be setup to use any of those databases and yet, it is rejected here - so I think this master-slave setup is a unique use-case that should be dealt with independently, like this, by selecting the master adapter explicitly and using that for all migration-related tasks.

That's my theory... (and it seems to work at least).  It does create a loose coupling between these two gems, since the master-slave adapter has to have a "master" method that returns a recognized adapter, and that's not already part of the DataMapper adapter spec/interface, but... I can't think of a better solution.
