### PR TITLE
Inherit DB field type from superclass

### DIFF
--- a/lib/dm-migrations/adapters/dm-do-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-do-adapter.rb
@@ -112,7 +112,7 @@ module DataMapper
       end
 
       module SQL #:nodoc:
-#        private  ## This cannot be private for current migrations
+        #        private  ## This cannot be private for current migrations
 
         # Adapters that support AUTO INCREMENT fields for CREATE TABLE
         # statements should overwrite this to return true
@@ -197,8 +197,14 @@ module DataMapper
         def property_schema_hash(property)
           dump_class = property.dump_class
           type_map   = self.class.type_map
+          next_property_class = property.class
+          type_by_property_class = nil
+          while (type_by_property_class.nil? && next_property_class < DataMapper::Property) do
+            type_by_property_class = type_map[next_property_class]
+            next_property_class = next_property_class.superclass
+          end
 
-          schema = (type_map[property.class] || type_map[dump_class]).merge(:name => property.field)
+          schema = (type_by_property_class || type_map[dump_class]).merge(:name => property.field)
 
           schema_primitive = schema[:primitive]
 

--- a/lib/dm-migrations/sql/table_creator.rb
+++ b/lib/dm-migrations/sql/table_creator.rb
@@ -84,12 +84,19 @@ module SQL
         else
           type_map  = @adapter.class.type_map
           primitive = type_class.respond_to?(:dump_as) ? type_class.dump_as : type_class
-          options   = (type_map[type_class] || type_map[primitive])
+          next_property_class = type_class
+          type_by_property_class = nil
+          while (type_by_property_class.nil? && next_property_class < DataMapper::Property) do
+            type_by_property_class = type_map[next_property_class]
+            next_property_class = next_property_class.superclass
+          end
+
+          options   = (type_by_property_class || type_map[primitive])
 
           schema.update(type_class.options) if type_class.respond_to?(:options)
           schema.update(options)
 
-          schema.delete(:length) if type_class == DataMapper::Property::Text
+          schema.delete(:length) if type_class <= DataMapper::Property::Text
         end
 
         schema.update(@opts)

--- a/spec/integration/sql_spec.rb
+++ b/spec/integration/sql_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+class MyCustomProperty < DataMapper::Property::Text; end # Column type is expected to be inherited from DataMapper::Property::Text (CLOB, TEXT or whatever)
+
 describe "SQL generation" do
 
   supported_by :postgres, :mysql, :sqlite, :oracle, :sqlserver do
@@ -23,6 +25,7 @@ describe "SQL generation" do
           column :id,          DataMapper::Property::Serial
           column :name,        'VARCHAR(50)', :allow_nil => false
           column :long_string, String, :size => 200
+          column :very_custom,  MyCustomProperty
         end
       end
 
@@ -46,7 +49,7 @@ describe "SQL generation" do
 
       it "should have an array of columns" do
         @creator.instance_eval("@columns").should be_kind_of(Array)
-        @creator.instance_eval("@columns").size.should == 3
+        @creator.instance_eval("@columns").size.should == 4
         @creator.instance_eval("@columns").first.should be_kind_of(DataMapper::Migration::TableCreator::Column)
       end
 
@@ -68,7 +71,7 @@ describe "SQL generation" do
       when :mysql
         it "should create an InnoDB database for MySQL" do
           #can't get an exact == comparison here because character set and collation may differ per connection
-          @creator.to_sql.should match(/^CREATE TABLE `people` \(`id` SERIAL PRIMARY KEY, `name` VARCHAR\(50\) NOT NULL, `long_string` VARCHAR\(200\)\) ENGINE = InnoDB CHARACTER SET \w+ COLLATE \w+\z/)
+          @creator.to_sql.should match(/^CREATE TABLE `people` \(`id` SERIAL PRIMARY KEY, `name` VARCHAR\(50\) NOT NULL, `long_string` VARCHAR\(200\), `very_custom` TEXT\) ENGINE = InnoDB CHARACTER SET \w+ COLLATE \w+\z/)
         end
 
         it "should allow for custom table creation options for MySQL" do
@@ -100,11 +103,11 @@ describe "SQL generation" do
 
       when :postgres
         it "should output a CREATE TABLE statement when sent #to_sql" do
-          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" SERIAL PRIMARY KEY, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200))}
+          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" SERIAL PRIMARY KEY, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200), "very_custom" TEXT)}
         end
-      when :sqlite3
+      when :sqlite3, :sqlite
         it "should output a CREATE TABLE statement when sent #to_sql" do
-          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200))}
+          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200), "very_custom" TEXT)}
         end
       end
 


### PR DESCRIPTION
Problem: All custom DataMapper::Properties (e.g. in dm-types) have database field types based upon their Ruby primitives. Especially Properties inheriting from DataMapper::Property::Text like DataMapper::Property::JSON have some problems with that behavior (since they will result in VARCARs instead of LOBs).

This commit adds logic to try to find a database field type based upon the superclasses of the (custom) property. Only if no superclass has a direkt mapping from Property.class to field type the fallback to the Ruby primitive (returned by `dump_as`) will take place.