### PR TITLE
Inherit DB field type from superclass (second try)

### DIFF
--- a/lib/dm-migrations/adapters/dm-do-adapter.rb
+++ b/lib/dm-migrations/adapters/dm-do-adapter.rb
@@ -196,9 +196,9 @@ module DataMapper
         # @api private
         def property_schema_hash(property)
           dump_class = property.dump_class
-          type_map   = self.class.type_map
+          type_by_property_class = self.class.type_by_property_class(property.class)
 
-          schema = (type_map[property.class] || type_map[dump_class]).merge(:name => property.field)
+          schema = (type_by_property_class || self.class.type_map[dump_class]).merge(:name => property.field)
 
           schema_primitive = schema[:primitive]
 
@@ -292,6 +292,17 @@ module DataMapper
             TrueClass        => { :primitive => 'BOOLEAN'                                           },
             Property::Text   => { :primitive => 'TEXT'                                              },
           }.freeze
+        end
+
+        # Finds a type for a given property.
+        #
+        # @return [Hash | nil] type matching the given property or one of the properties ancestors
+        #
+        # @api private
+        def type_by_property_class(property_class)
+          return nil unless property_class < DataMapper::Property
+
+          type_map[property_class] || type_by_property_class(property_class.superclass)
         end
       end
     end

--- a/lib/dm-migrations/sql/table_creator.rb
+++ b/lib/dm-migrations/sql/table_creator.rb
@@ -82,14 +82,13 @@ module SQL
         if type_class.kind_of?(String)
           schema[:primitive] = type_class
         else
-          type_map  = @adapter.class.type_map
           primitive = type_class.respond_to?(:dump_as) ? type_class.dump_as : type_class
-          options   = (type_map[type_class] || type_map[primitive])
+          options   = @adapter.class.type_by_property_class(type_class) || @adapter.class.type_map[primitive]
 
           schema.update(type_class.options) if type_class.respond_to?(:options)
           schema.update(options)
 
-          schema.delete(:length) if type_class == DataMapper::Property::Text
+          schema.delete(:length) if type_class <= DataMapper::Property::Text
         end
 
         schema.update(@opts)

--- a/spec/integration/sql_spec.rb
+++ b/spec/integration/sql_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+class MyCustomProperty < DataMapper::Property::Text; end # Column type is expected to be inherited from DataMapper::Property::Text (CLOB, TEXT or whatever)
+
 describe "SQL generation" do
 
   supported_by :postgres, :mysql, :sqlite, :oracle, :sqlserver do
@@ -23,6 +25,7 @@ describe "SQL generation" do
           column :id,          DataMapper::Property::Serial
           column :name,        'VARCHAR(50)', :allow_nil => false
           column :long_string, String, :size => 200
+          column :very_custom,  MyCustomProperty
         end
       end
 
@@ -46,7 +49,7 @@ describe "SQL generation" do
 
       it "should have an array of columns" do
         @creator.instance_eval("@columns").should be_kind_of(Array)
-        @creator.instance_eval("@columns").size.should == 3
+        @creator.instance_eval("@columns").size.should == 4
         @creator.instance_eval("@columns").first.should be_kind_of(DataMapper::Migration::TableCreator::Column)
       end
 
@@ -68,7 +71,7 @@ describe "SQL generation" do
       when :mysql
         it "should create an InnoDB database for MySQL" do
           #can't get an exact == comparison here because character set and collation may differ per connection
-          @creator.to_sql.should match(/^CREATE TABLE `people` \(`id` SERIAL PRIMARY KEY, `name` VARCHAR\(50\) NOT NULL, `long_string` VARCHAR\(200\)\) ENGINE = InnoDB CHARACTER SET \w+ COLLATE \w+\z/)
+          @creator.to_sql.should match(/^CREATE TABLE `people` \(`id` SERIAL PRIMARY KEY, `name` VARCHAR\(50\) NOT NULL, `long_string` VARCHAR\(200\), `very_custom` TEXT\) ENGINE = InnoDB CHARACTER SET \w+ COLLATE \w+\z/)
         end
 
         it "should allow for custom table creation options for MySQL" do
@@ -100,11 +103,11 @@ describe "SQL generation" do
 
       when :postgres
         it "should output a CREATE TABLE statement when sent #to_sql" do
-          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" SERIAL PRIMARY KEY, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200))}
+          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" SERIAL PRIMARY KEY, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200), "very_custom" TEXT)}
         end
-      when :sqlite3
+      when :sqlite3, :sqlite
         it "should output a CREATE TABLE statement when sent #to_sql" do
-          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200))}
+          @creator.to_sql.should == %q{CREATE TABLE "people" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" VARCHAR(50) NOT NULL, "long_string" VARCHAR(200), "very_custom" TEXT)}
         end
       end
 

--- a/spec/unit/sql/table_creator_spec.rb
+++ b/spec/unit/sql/table_creator_spec.rb
@@ -63,6 +63,7 @@ describe 'SQL module' do
 
         @adapter.stub!(:quote_column_name).and_return(%{'id'})
         @adapter.class.stub!(:type_map).and_return(Integer => {:type => 'int'})
+        @adapter.class.stub!(:type_by_property_class).and_return(Integer => {:type => 'int'})
         @adapter.stub!(:property_schema_statement).and_return("SOME SQL")
         @adapter.stub!(:with_connection).and_yield(connection)
         @c = SQL::TableCreator::Column.new(@adapter, 'id', Integer, :serial => true)


### PR DESCRIPTION
Problem: All custom DataMapper::Properties (e.g. in dm-types) have database field types based upon their Ruby primitives. Especially Properties inheriting from DataMapper::Property::Text like DataMapper::Property::JSON have some problems with that behavior (since they will result in VARCARs instead of LOBs).

This commit adds logic to try to find a database field type based upon the superclasses of the (custom) property. Only if no superclass has a direkt mapping from `property.class` to field type the fallback to the Ruby primitive (returned by dump_as) will take place.

This PR follows a cleaner approach then #54 